### PR TITLE
fixes the deprecated stime call

### DIFF
--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -7655,10 +7655,12 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
 #ifdef TARGET_NR_stime /* not on alpha */
     case TARGET_NR_stime:
         {
-            time_t host_time;
-            if (get_user_sal(host_time, arg1))
+            struct timespec ts;
+            ts.tv_nsec = 0;
+            if (get_user_sal(ts.tv_sec, arg1)) {
                 return -TARGET_EFAULT;
-            return get_errno(stime(&host_time));
+            }
+            return get_errno(clock_settime(CLOCK_REALTIME, &ts));
         }
 #endif
 #ifdef TARGET_NR_alarm /* not on alpha */


### PR DESCRIPTION
- closes #3 with a matching patch from the qemu [upstream patch](https://github.com/qemu/qemu/commit/0f1f2d4596aee037d3ccbcf10592466daa54107f)
- fixes building on Ubuntu 20.04 which uses a current glibc
stime [manpage reference](https://man7.org/linux/man-pages/man2/stime.2.html)